### PR TITLE
`tests` directory should not be a package: remove `tests/__init__.py` and exclude it from `find_resources`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ The decisions `cookiecutter-pypackage-minimal` makes should all be explained her
   This can be changed easily, though pytest is a easier, more powerful test library and runner than the standard library's unittest.
 * **Define testing dependencies in `tox.ini`**
   Avoid duplicating dependency definitions, and use `tox.ini` as the canonical description of how the unittests should be run.
+* **`tests` directory should not be a package**
+  The `tests` directory should not be a Python package unless you want to define some fixtures.
+  But the best practices are to use [PyTest fixtures](https://docs.pytest.org/en/latest/fixture.html) which provides a better solution.
+  Therefore, the `tests` directory has no `__init__.py` file.

--- a/{{cookiecutter.package_name}}/setup.py
+++ b/{{cookiecutter.package_name}}/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description="{{ cookiecutter.package_description }}",
     long_description=open('README.rst').read(),
 
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=('tests',)),
 
     install_requires=[],
 


### PR DESCRIPTION
The purpose of this PR is to fix #11:

* Exclude the tests directory from the list of packages in the call of `find_packages`.
* The `tests` directory should not be a Python package.