### PR TITLE
README.rst use 'utf-8' encoding / drop Sphinx directives

### DIFF
--- a/{{cookiecutter.package_name}}/setup.py
+++ b/{{cookiecutter.package_name}}/setup.py
@@ -1,6 +1,19 @@
-import setuptools
+import io
+import os
+import re
 
-setuptools.setup(
+from setuptools import find_packages
+from setuptools import setup
+
+
+def read(filename):
+    filename = os.path.join(os.path.dirname(__file__), filename)
+    text_type = type(u"")
+    with io.open(filename, mode="r", encoding='utf-8') as fd:
+        return re.sub(text_type(r':[a-z]+:`~?(.*?)`'), text_type(r'``\1``'), fd.read())
+
+
+setup(
     name="{{ cookiecutter.package_name }}",
     version="{{ cookiecutter.package_version }}",
     url="{{ cookiecutter.package_url }}",
@@ -9,9 +22,9 @@ setuptools.setup(
     author_email="{{ cookiecutter.author_email }}",
 
     description="{{ cookiecutter.package_description }}",
-    long_description=open('README.rst').read(),
+    long_description=read("README.rst"),
 
-    packages=setuptools.find_packages(),
+    packages=find_packages(),
 
     install_requires=[],
 


### PR DESCRIPTION
The purpose of the PR is to change the way `README.rst` is read.

I see several pitfalls about the way `README.rst`is read to populate the `long_description`:

* A reStructuredFile use 'utf-8' encoding by default. So, you need to specify this encoding (if you use Python 2.7). If you don't, `python setup.py` will failed if the README.rst file contains non-ASCII characters.
* The `README.rst` file may contains [Sphinx](http://www.sphinx-doc.org) directives. This directives are no supported (when displaying the description on PyPi). You can remove it (and use double back ticks instead).
* The file `README.rst` is opened but not closed (until Python script ends). The best practices is to use a `with` statement to open the file.

This PR solves this pitfalls.

Regards,
– Laurent.