### PR TITLE
README.rst uses 'utf-8' / Drop Sphinx Directives

### DIFF
--- a/{{cookiecutter.package_name}}/setup.py
+++ b/{{cookiecutter.package_name}}/setup.py
@@ -1,6 +1,19 @@
-import setuptools
+import io
+import os
+import re
 
-setuptools.setup(
+from setuptools import find_packages
+from setuptools import setup
+
+
+def read(filename):
+    filename = os.path.join(os.path.dirname(__file__), filename)
+    text_type = type(u"")
+    with io.open(filename, mode="r", encoding='utf-8') as fd:
+        return re.sub(text_type(r':[a-z]+:`~?(.*?)`'), text_type(r'``\1``'), fd.read())
+
+
+setup(
     name="{{ cookiecutter.package_name }}",
     version="{{ cookiecutter.package_version }}",
     url="{{ cookiecutter.package_url }}",
@@ -9,9 +22,9 @@ setuptools.setup(
     author_email="{{ cookiecutter.author_email }}",
 
     description="{{ cookiecutter.package_description }}",
-    long_description=open('README.rst').read(),
+    long_description=read("README.rst"),
 
-    packages=setuptools.find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=('tests',)),
 
     install_requires=[],
 


### PR DESCRIPTION
The purpose of this PR is to:

- Read the `README.rst` file using 'utf-8' encoding,
- Drop the potential Sphinx directives (use double back ticks instead),
- Close the `README.rst`file,

With Python 2.7, you must specify the file encoding because, if `README.rst` file contains non-ASCII character, the command `python setup.py` will fail.

Nowadays, `README.rst` files may contains Sphinx directives (to show code sample). This directives are non standard reStructuredText directive and should be replace. Without that, the description won't show correctly on PyPi.

Regards,
– Laurent.