### PR TITLE
Support for Python 3.6 and 3.7

### DIFF
--- a/{{cookiecutter.package_name}}/setup.py
+++ b/{{cookiecutter.package_name}}/setup.py
@@ -23,5 +23,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist=py27,py34,py35
+envlist = py27,py34,py35,py36,py37
 
 [testenv]
-commands=py.test {{ cookiecutter.package_name }}
-deps=pytest
+commands = py.test {{ cookiecutter.package_name }}
+deps = pytest


### PR DESCRIPTION
Change the Tox configuration and `setup.py` to support Python 3.6 and 3.7