### PR TITLE
Add the possibility for the developer to choose the README file format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ The decisions `cookiecutter-pypackage-minimal` makes should all be explained her
 
 ### README
 
-* **README should use reStructuredText format**
-  This is the format used by most Python tools, is expected by [setuptools](https://setuptools.readthedocs.io), and can be used by [Sphinx](http://sphinx-doc.org/).
+* **README can use reStructuredText, Markdown or Text format**
+  This template gives you the possibility to choose between reStructuredText, Markdown or the (legacy) Text format.
+  [reStructuredText](http://docutils.sourceforge.net/rst.html) is the format used by most Python tools, but, nowadays, [Markdown](https://github.github.com/gfm/) is so popular that it is now supported by [setuptools](https://setuptools.readthedocs.io) and can be used by [Sphinx](http://sphinx-doc.org/).
 * **As few README files as possible**
   Additional README files (AUTHORS, CHANGELOG, etc) should be left to the user to create when necessary.
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,7 @@
     
     "readme_pypi_badge": true,
     "readme_travis_badge": true,
-    "readme_travis_url": "https://travis-ci.org/borntyping/cookiecutter-pypackage-minimal"
+    "readme_travis_url": "https://travis-ci.org/borntyping/cookiecutter-pypackage-minimal",
+
+    "long_description_file": ["README.rst", "README.md", "README.txt", "README"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+from __future__ import print_function
+
+import os
+
+LONG_DESCRIPTION_FILES = ["README.rst", "README.md", "README.txt", "README"]
+
+
+def drop_extra_long_description_files():
+    long_description_file = '{{ cookiecutter.long_description_file }}'
+    to_drop = [name for name in LONG_DESCRIPTION_FILES if name != long_description_file]
+    print("- Droping extra long description files: {0}".format(", ".join(to_drop)))
+    for name in to_drop:
+        os.remove(name)
+
+
+if __name__ == '__main__':
+    print("Running post-generate hooks...")
+    drop_extra_long_description_files()
+    print("Done.")

--- a/{{cookiecutter.package_name}}/README
+++ b/{{cookiecutter.package_name}}/README
@@ -1,0 +1,24 @@
+{{ cookiecutter.package_name }}
+{{ cookiecutter.package_name|count * "=" }}
+
+{{ cookiecutter.package_description }}
+
+Usage
+-----
+
+Installation
+------------
+
+Requirements
+^^^^^^^^^^^^
+
+Compatibility
+-------------
+
+Licence
+-------
+
+Authors
+-------
+
+`{{ cookiecutter.package_name }}` was written by `{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>`_.

--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -1,0 +1,26 @@
+{{ cookiecutter.package_name }}
+{{ cookiecutter.package_name|count * "=" }}
+
+{% if cookiecutter.readme_pypi_badge -%}
+[![Latest PyPI version](https://img.shields.io/pypi/v/{{ cookiecutter.package_name }}.svg)](https://pypi.python.org/pypi/{{ cookiecutter.package_name }})
+{%- endif %}
+
+{% if cookiecutter.readme_travis_badge -%}
+[![Latest Travis CI build status]({{ cookiecutter.readme_travis_url }}.png)]({{ cookiecutter.readme_travis_url }})
+{%- endif %}
+
+{{ cookiecutter.package_description }}
+
+# Usage
+
+# Installation
+
+## Requirements
+
+# Compatibility
+
+# Licence
+
+# Authors
+
+`{{ cookiecutter.package_name }}` was written by [{{ cookiecutter.author_name }}]({{ cookiecutter.author_email }}).

--- a/{{cookiecutter.package_name}}/README.txt
+++ b/{{cookiecutter.package_name}}/README.txt
@@ -1,0 +1,24 @@
+{{ cookiecutter.package_name }}
+{{ cookiecutter.package_name|count * "=" }}
+
+{{ cookiecutter.package_description }}
+
+Usage
+-----
+
+Installation
+------------
+
+Requirements
+^^^^^^^^^^^^
+
+Compatibility
+-------------
+
+Licence
+-------
+
+Authors
+-------
+
+`{{ cookiecutter.package_name }}` was written by `{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>`_.

--- a/{{cookiecutter.package_name}}/setup.py
+++ b/{{cookiecutter.package_name}}/setup.py
@@ -1,3 +1,13 @@
+"""
+{{ cookiecutter.package_name }}'s configuration file
+{%
+set long_description_content_type = {"README.rst": "text/x-rst",
+                                     "README.md": "text/markdown",
+                                     "README.txt": "text/plain",
+                                     "README": "text/plain"}[cookiecutter.long_description_file]
+-%}
+"""
+
 import io
 import os
 import re
@@ -23,7 +33,8 @@ setup(
     author_email="{{ cookiecutter.author_email }}",
 
     description="{{ cookiecutter.package_description }}",
-    long_description=read("README.rst"),
+    long_description=read("{{ cookiecutter.long_description_file }}"),
+    long_description_content_type="{{ long_description_content_type }}",
 
     packages=find_packages(exclude=('tests',)),
 


### PR DESCRIPTION
This is a new feature to add the possibility for the developer to choose the README file format:

* **README can use reStructuredText, Markdown or Text format**
  This template gives you the possibility to choose between reStructuredText, Markdown or the (legacy) Text format.
  [reStructuredText](http://docutils.sourceforge.net/rst.html) is the format used by most Python tools, but, nowadays, [Markdown](https://github.github.com/gfm/) is so popular that it is now supported by [setuptools](https://setuptools.readthedocs.io) and can be used by [Sphinx](http://sphinx-doc.org/).

**Changes**

- Add a new `long_description_file` variable in the `cookiecutter.json` file with the possibles choices: ["README.rst", "README.md", "README.txt", "README"],
- Add as many README files as formats,
- Add a hook script to drop the extra files on post-generation, and keep only the relevant one,
- Change the `setup.py` to fill the `long_description_content_type` according to the selected README format: "text/x-rst", "text/markdown" or "text/plain".
- Update the `README.md` to explain the new feature.

**Tested**

The package generation can be tested as follow:

```bash
cookiecutter /path/to/cookiecutter-pypackage-minimal  # or use the full URL
```

Then fill the fields, and select a README file format. Then build the `sdist` and check the readme with `twine`:

```bash
cd package_name
python setup.py sdist
twine check dist/*
```

You should have:

```
Checking distribution dist/package_name-0.1.0.tar.gz: Passed
```
