### PR TITLE
Fix invalid command used to run PyTest with tox: the parameter should…

### DIFF
--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -2,5 +2,5 @@
 envlist = py27,py34,py35,py36,py37
 
 [testenv]
-commands = py.test {{ cookiecutter.package_name }}
+commands = py.test tests
 deps = pytest


### PR DESCRIPTION
Fix invalid command used to run PyTest with tox: the parameter should be the `tests` directory.

Replace: `commands = py.test {{ cookiecutter.package_name }}`
With: `commands = py.test tests`,

Where `tests` is the tests directory…