### PR TITLE
Update broken project links

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,9 +5,9 @@
     "package_name": "cookiecutter_pypackage_minimal",
     "package_version": "0.1.0",
     "package_description": "An opinionated, minimal cookiecutter template for Python packages",
-    "package_url": "https://github.com/borntyping/cookiecutter-pypackage-minimal",
+    "package_url": "https://github.com/kragniz/cookiecutter-pypackage-minimal",
     
     "readme_pypi_badge": true,
     "readme_travis_badge": true,
-    "readme_travis_url": "https://travis-ci.org/borntyping/cookiecutter-pypackage-minimal"
+    "readme_travis_url": "https://travis-ci.org/kragniz/cookiecutter-pypackage-minimal"
 }


### PR DESCRIPTION
Guess you've moved the project namespaces recently and forgot to update the template...